### PR TITLE
Fixed the travisci erlang 17.5 build but unsure about the rust part

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 Cargo.lock
 target/
+*.*~
+.*~
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ before_script:
   - ./kerl list releases
   - ./kerl list installations
   - ./kerl build 17.5 erlang-17.5
-  - ./kerl install 17.5 && ./kerl cleanup
+  - ./kerl list builds
+  - ./kerl install erlang-17.5 && ./kerl cleanup
   - ./kerl list installations
   - ./kerl active
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - ./kerl list builds
   - ./kerl install erlang-17.5 ./otp
   - chmod a+x ./otp/activate 
-  - ./otp/activate && ./kerl active
+  - ./otp/activate
   - ./kerl cleanup all
   - ./kerl list installations 
   -  erl -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ before_script:
   - ./kerl list installations
   - ./kerl build 17.5 erlang-17.5
   - ./kerl list builds
-  - ./kerl install erlang-17.5 && ./kerl cleanup
+  - ./kerl install erlang-17.5 
+  - ./activate
+  - ./kerl cleanup all
   - ./kerl list installations
   - ./kerl active
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ before_script:
   - ./kerl list installations
   - ./kerl build 17.5 erlang-17.5
   - ./kerl install && ./kerl cleanup
-
+  - ./kerl install && ./kerl cleanup
+  - ./kerl list installations
+  - ./kerl active
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
   - ./kerl list releases
   - ./kerl list installations
   - ./kerl build 17.5 erlang-17.5
+  - ./kerl install && ./kerl cleanup
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,7 @@ before_script:
   - ./kerl list releases
   - ./kerl list installations
   - ./kerl build 17.5 erlang-17.5
+
+branches:
+  only:
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ before_script:
   - ./kerl list releases
   - ./kerl list installations
   - ./kerl build 17.5 erlang-17.5
-  - ./kerl install && ./kerl cleanup
-  - ./kerl install && ./kerl cleanup
+  - ./kerl install 17.5 && ./kerl cleanup
   - ./kerl list installations
   - ./kerl active
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@
 #language: c
 language: rust
 
-env:
-  global:
-    - INSTALL_DIR=%{TRAVIS_BUILD_DIR}
 
 before_script:
   - curl -O https://raw.githubusercontent.com/spawngrid/kerl/master/kerl
@@ -15,9 +12,9 @@ before_script:
   - ./kerl list installations
   - ./kerl build 17.5 erlang-17.5
   - ./kerl list builds
-  - ./kerl install erlang-17.5 %{INSTALL_DIR}
-  - chmod a+x %{INSTALL_DIR}/activate 
-  - %{INSTALL_DIR}/activate
+  - ./kerl install erlang-17.5 `pwd`/otp
+  - chmod a+x `pwd`/otp/activate 
+  - `pwd`/otp/activate
   - ./kerl cleanup all
   - ./kerl list installations
   - ./kerl active

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@
 #language: c
 language: rust
 
-
-before_script:
+install:
   - curl -O https://raw.githubusercontent.com/spawngrid/kerl/master/kerl
   - chmod a+x kerl
   - pwd
@@ -14,10 +13,11 @@ before_script:
   - ./kerl list builds
   - ./kerl install erlang-17.5 ./otp
   - chmod a+x ./otp/activate 
-  - ./otp/activate
+  - ./otp/activate && ./kerl active
   - ./kerl cleanup all
-  - ./kerl list installations
-  - ./kerl active
+  - ./kerl list installations 
+  -  erl -version
+
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: rust
 before_script:
   - curl -O https://raw.githubusercontent.com/spawngrid/kerl/master/kerl
   - chmod a+x kerl
+  - ./kerl update releases
   - ./kerl list releases
   - ./kerl list installations
   - ./kerl build 17.5 erlang-17.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
 #sudo: required
 #language: c
 language: rust
+
+env:
+  global:
+    - INSTALL_DIR=%{TRAVIS_BUILD_DIR}
+
 before_script:
   - curl -O https://raw.githubusercontent.com/spawngrid/kerl/master/kerl
   - chmod a+x kerl
+  - pwd
   - ./kerl update releases
   - ./kerl list releases
   - ./kerl list installations
   - ./kerl build 17.5 erlang-17.5
   - ./kerl list builds
-  - ./kerl install erlang-17.5 
-  - ./activate
+  - ./kerl install erlang-17.5 %{INSTALL_DIR}
+  - chmod a+x %{INSTALL_DIR}/activate 
+  - %{INSTALL_DIR}/activate
   - ./kerl cleanup all
   - ./kerl list installations
   - ./kerl active

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ before_script:
   - ./kerl list installations
   - ./kerl build 17.5 erlang-17.5
   - ./kerl list builds
-  - ./kerl install erlang-17.5 `pwd`/otp
-  - chmod a+x `pwd`/otp/activate 
-  - `pwd`/otp/activate
+  - ./kerl install erlang-17.5 ./otp
+  - chmod a+x ./otp/activate 
+  - ./otp/activate
   - ./kerl cleanup all
   - ./kerl list installations
   - ./kerl active


### PR DESCRIPTION
Hi,
I have fixed the 17.5 erlang build error part in travis.yml.
Need to issue kerl update so kerl can update release form erlang solutions.
Kerl is not that well maintained but that is what travis uses.I suspect they did not issue kerl update also so their travis erlang releases is alwasy behind.
I am unsure how to fix the rust NIF part. I am unfamialr with rust.
You can see my build log: 
https://travis-ci.org/linearregression/ruster_unsafe/builds/65131238