### PR TITLE
Support nif 2.9 in OTP 18.2

### DIFF
--- a/gen_api.erl
+++ b/gen_api.erl
@@ -9,7 +9,10 @@
 %% the Windows callback struct keeps proper integrity.  Such functions
 %% must begin with "dummy."
 %%
-api_list(Version, Wordsize, HasDirtySchedulers) when Version=={2,7} orelse Version=={2,8} -> [
+api_list(Version, Wordsize, HasDirtySchedulers)
+  when Version =:= {2,7};
+       Version =:= {2,8};
+       Version =:= {2,9} -> [
 
     {"*mut c_void", "enif_priv_data", "arg1: *mut ErlNifEnv"},
     {"*mut c_void", "enif_alloc", "size: size_t"},
@@ -188,13 +191,24 @@ api_list(Version, Wordsize, HasDirtySchedulers) when Version=={2,7} orelse Versi
 
 
 
-    case Version of
-        {2,8} -> [
+    case lists:member(Version, [{2,8}, {2,9}]) of
+        true -> [
             {"c_int", "enif_has_pending_exception", "env: *mut ErlNifEnv, reason: *mut ERL_NIF_TERM"},
             {"ERL_NIF_TERM", "enif_raise_exception", "env: *mut ErlNifEnv, reason: ERL_NIF_TERM"}
         ];
+        false -> []
+    end ++
+
+
+
+    case Version of
+        {2,9} -> [
+            {"c_int", "enif_getenv", "key: *const c_uchar, value: *mut c_uchar, value_size: *mut size_t"}
+        ];
         _ -> []
     end ++
+
+
 
     case HasDirtySchedulers of
         true -> [{"c_int", "enif_is_on_dirty_scheduler", "env: *mut ErlNifEnv"}  ];
@@ -302,6 +316,7 @@ get_nif_version() ->
 
 version_string2tuple("2.7") -> {2,7};
 version_string2tuple("2.8") -> {2,8};
+version_string2tuple("2.9") -> {2,9};
 version_string2tuple(_) -> unsupported.
 
 check_version(unsupported) ->


### PR DESCRIPTION
Add `enif_getenv()` function to support nif 2.9. `enif_getenv()` was introduced to  Erlang/OTP 18.2 by this commit: https://github.com/erlang/otp/commit/ef45d2c9f874354b17c2aca96de7b3306a9eb943

Manually tested with a modified version of ruster_unsafe_demo: https://github.com/tatsuya6502/ruster_unsafe_demo/commit/839db584e147459f714e5658d62e8a580c382bf2

```console
% git remote -v
origin	git@github.com:tatsuya6502/ruster_unsafe_demo.git (fetch)
origin	git@github.com:tatsuya6502/ruster_unsafe_demo.git (push)
% git branch
  master
* nif-2.9
% cargo build
    Updating git repository `https://github.com/tatsuya6502/ruster_unsafe/`
    Updating registry `https://github.com/rust-lang/crates.io-index`
   Compiling ruster_unsafe v0.2.0 (https://github.com/tatsuya6502/ruster_unsafe/?rev=nif-2.9#2f68285f)
   Compiling libc v0.2.4
   Compiling ruster_unsafe_demo v0.0.1 (file:///usr/home/tatsuya/workhub/dev/ruster_unsafe_demo)
% erlc ruster_unsafe_demo.erl
%
```

```erl
% erl
Erlang/OTP 18 [erts-7.2.1] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V7.2.1  (abort with ^G)
1> ruster_unsafe_demo:getenv("HOME").
"/home/tatsuya"
2> ruster_unsafe_demo:getenv("UNDEFINED").
** exception error: bad argument
     in function  ruster_unsafe_demo:getenv/1
        called as ruster_unsafe_demo:getenv("UNDEFINED")
3> os:getenv("HOME").
"/home/tatsuya"
4> os:getenv("UNDEFINED").
false
```