### PR TITLE
make ErlNifBinary.data mutable (GH08)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ pub struct ErlNifEntry {
 #[repr(C)]
 pub struct ErlNifBinary {
     pub size: size_t,
-    pub data: *const u8,
+    pub data: *mut u8,
     bin_term: ERL_NIF_TERM,
     ref_bin: *mut c_void,
 }


### PR DESCRIPTION
To fix https://github.com/goertzenator/ruster_unsafe/issues/8, change `ErlNifBinary.data` from `*const u8` to `*mut u8`, so that the contents of data can be modified from Rust world.
